### PR TITLE
fix: memory leak

### DIFF
--- a/src/EventTarget.js
+++ b/src/EventTarget.js
@@ -1,4 +1,4 @@
-const _events = new Map()
+const _events = new WeakMap()
 
 class Touch {
     constructor(touch) {


### PR DESCRIPTION
using `Weakmap` instead of `Map` to fix memory leak