### PR TITLE
fix: GLTFloader

### DIFF
--- a/example/loaders/gltf-loader.js
+++ b/example/loaders/gltf-loader.js
@@ -1970,7 +1970,7 @@ export function registerGLTFLoader(THREE) {
       var options = this.options;
       var textureLoader = this.textureLoader;
 
-      var URL = window.URL || window.webkitURL;
+      // var URL = window.URL || window.webkitURL;
 
       var textureDef = json.textures[textureIndex];
 
@@ -1998,9 +1998,14 @@ export function registerGLTFLoader(THREE) {
         sourceURI = parser.getDependency('bufferView', source.bufferView).then(function (bufferView) {
 
           isObjectURL = true;
-          var blob = new Blob([bufferView], { type: source.mimeType });
-          sourceURI = URL.createObjectURL(blob);
-          return sourceURI;
+          // var blob = new Blob([bufferView], { type: source.mimeType });
+          // sourceURI = URL.createObjectURL(blob);
+          // return sourceURI;
+
+            // 微信小程序不支持 Blob 对象，则使用 base64 编码的字符串来创建 data URI
+            const base64Str = wx.arrayBufferToBase64(bufferView);
+            sourceURI = `data:${source.mimeType};base64,${base64Str}`;
+            return sourceURI
 
         });
 
@@ -2032,7 +2037,7 @@ export function registerGLTFLoader(THREE) {
 
         if (isObjectURL === true) {
 
-          URL.revokeObjectURL(sourceURI);
+          // URL.revokeObjectURL(sourceURI);
 
         }
 


### PR DESCRIPTION
修复GLTFLoader加载gltf模型时报错：

**- 原因：**

微信小程序不支持Blob 对象, URL对象

**- 修复方式：**

使用 base64 编码的字符串来创建 data URI

**- 复现方式**
   可以使用这个模型

https://mmbizwxaminiprogram-1258344707.cos.ap-guangzhou.myqcloud.com/xr-frame/demo/butterfly/index.glb

报错截图如下
![image](https://github.com/wechat-miniprogram/threejs-miniprogram/assets/38858428/7e976e28-f5e4-4569-a891-f00b7d074042)

![image](https://github.com/wechat-miniprogram/threejs-miniprogram/assets/38858428/f6398fd7-93f7-4577-9997-691ee52027aa)
